### PR TITLE
adds ability to use long prop name for px, py, mx, my

### DIFF
--- a/packages/system/src/styles/space.js
+++ b/packages/system/src/styles/space.js
@@ -62,13 +62,13 @@ export const marginLeft = style({
 })
 
 export const mx = style({
-  prop: 'mx',
+  prop: ['marginHorizontal', 'mx'],
   cssProperty: ['marginRight', 'marginLeft'],
   themeGet: getSpace,
 })
 
 export const my = style({
-  prop: 'my',
+  prop: ['marginVertical', 'my'],
   cssProperty: ['marginTop', 'marginBottom'],
   themeGet: getSpace,
 })
@@ -104,13 +104,13 @@ export const paddingLeft = style({
 })
 
 export const px = style({
-  prop: 'px',
+  prop: ['paddingHorizontal', 'px'],
   cssProperty: ['paddingRight', 'paddingLeft'],
   themeGet: getSpace,
 })
 
 export const py = style({
-  prop: 'py',
+  prop: ['paddingVertical', 'py'],
   cssProperty: ['paddingTop', 'paddingBottom'],
   themeGet: getSpace,
 })


### PR DESCRIPTION
## Summary

We're using xstyled inside a component library and at some point we decided to use long prop names instead of short ones. paddingLeft and paddingRight works but we couldn't access for px and py with a long name. We assumed it would be useful maybe others wanted to use this naming convention.

## Test plan

I just added aliases for spacing cases. I don't know where to look for test