### PR TITLE
Fix example in docs

### DIFF
--- a/website/src/pages/docs/responsive.mdx
+++ b/website/src/pages/docs/responsive.mdx
@@ -35,9 +35,9 @@ Grid system are [bootstrap like](https://getbootstrap.com/) grids. It gives you 
 
 // By default, cols measure 100%, start from "md" breakpoint: they measure "1/3" of the size
 <Box row>
-  <Box col={ xs: 1, md: { 1 / 3 }} />
-  <Box col={ xs: 1, md: { 1 / 3 }} />
-  <Box col={ xs: 1, md: { 1 / 3 }} />
+  <Box col={{ xs: 1, md: 1 / 3 }} />
+  <Box col={{ xs: 1, md: 1 / 3 }} />
+  <Box col={{ xs: 1, md: 1 / 3 }} />
 </Box>
 
 // First col use the size of content, others share the space


### PR DESCRIPTION
Just started working with the library and noticed an issue with the docs.

The formatting for the responsive box was incorrect. It needs to be wrapped in another set of brackets `{}` to be made into an object, and the brackets around the `1/3` need to be removed (because it should be a direct property of `md`, not a nested one).

Should be an easy merge 👍I haven't tested this in the monorepo, just a quick edit. Let me know if I messed up the syntax 😅

- [Here is an example of copying code from the docs](https://codesandbox.io/s/xstyled-responsive-docs-issue-vw545?file=/src/App.js)
- [Here is an example of the fixed code I added to the docs](https://codesandbox.io/s/xstyled-responsive-docs-fix-l3xg6?file=/src/App.js)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
