### PR TITLE
fix(breakpoints): useThemeUp inclusive min

### DIFF
--- a/packages/core/src/breakpoints.js
+++ b/packages/core/src/breakpoints.js
@@ -62,7 +62,7 @@ export function useThemeBreakpoint(theme) {
 export function useThemeUp(theme, key) {
   const value = useThemeMinValue(theme, key)
   const width = useViewportWidth()
-  return width > value
+  return width >= value
 }
 
 export function useThemeDown(theme, key) {


### PR DESCRIPTION
## Summary

useThemeDown is exclusive so useThemeUp should be inclusive, otherwise
there's a hole when width is exactly value.

## Test plan

Testing amounted to staring at the code and noticing this bug while working on
something unrelated (see #114)