### PR TITLE
fix(breakpoints): races in useViewportWidth

### DIFF
--- a/packages/core/src/breakpoints.js
+++ b/packages/core/src/breakpoints.js
@@ -31,16 +31,17 @@ function useThemeMaxValue(theme, key) {
 }
 
 export function useViewportWidth() {
-  const [width, setWidth] = React.useState(null)
+  const [width, setWidth] = React.useState(typeof window === 'undefined' ? null : window.innerWidth)
 
-  React.useLayoutEffect(() => {
-    setWidth(window.innerWidth)
-
+  React.useEffect(() => {
     function handleResize() {
       setWidth(window.innerWidth)
     }
 
+    // Add the listener, then setWidth to avoid race.
     window.addEventListener('resize', handleResize)
+    setWidth(window.innerWidth)
+
     return () => window.removeEventListener('resize', handleResize)
   }, [])
 


### PR DESCRIPTION
## Summary

The main fix here is changing the initial state from null to
window.innerWidth, so that there isn't a useless transition from (for
example) `useDown('md') = true` to `useDown('md') = false` when the
application loads. Depending on the application, the rerendering penalty
can be heavy.

While we're here, notice that we can make a couple related changes:
First, since the initial state is set properly, we don't need a layout
effect, instead we can use a normal effect. Second, swap the order of
listener and setWidth to avoid the tiny race between them.

## Test plan

This cropped up for me in storybook. I have a component that measures its
container to make image layout decisions. On the first load of the app, it would
work, but on hot reload, the image would be the wrong size.

The problem is that `useDown('md')` returns the wrong value the first time. It
was okay on initial app load because image loading slowed things down enough
that `useDown('md')` would return the right value before the measurement.
However on hot reload, when the image is already loaded, the measurement would
fire in the window of time between the bogus `useDown` and the right `useDown`.

Note that the measurement code also reruns on resize, but since there's no
resize occurring, it wouldn't know to remeasure.

Making this change fixed the problem for me.