### PR TITLE
Add missing `shrink` and `grow` props

### DIFF
--- a/packages/system/src/styles/flexboxes.js
+++ b/packages/system/src/styles/flexboxes.js
@@ -22,6 +22,14 @@ export const flexWrap = style({
   prop: 'flexWrap',
 })
 
+export const flexGrow = style({
+  prop: 'flexGrow',
+})
+
+export const flexShrink = style({
+  prop: 'flexShrink',
+})
+
 export const flexBasis = style({
   prop: 'flexBasis',
   themeGet: getPercent,
@@ -55,6 +63,8 @@ export const flexboxes = compose(
   justifyItems,
   flexWrap,
   flexBasis,
+  flexShrink,
+  flexGrow,
   flexDirection,
   flex,
   justifySelf,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

flex can cover `grow`, `shrink` and `basis`. Because we already have `basis`, I think it's a good idea to also add `shrink` and `grow` for consistency.

