### PR TITLE
fix: adds keyframes to emotion exports

### DIFF
--- a/packages/emotion/src/index.js
+++ b/packages/emotion/src/index.js
@@ -11,6 +11,7 @@ export {
   ThemeContext,
   Global,
   ClassNames,
+  keyframes,
 } from '@emotion/core'
 export { ThemeProvider, withTheme, useTheme } from 'emotion-theming'
 export * from './breakpoints'

--- a/packages/emotion/src/styled.test.js
+++ b/packages/emotion/src/styled.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, cleanup } from '@testing-library/react'
 import { ThemeProvider } from 'emotion-theming'
-import styled, { css } from '.'
+import styled, { css, keyframes } from '.'
 
 afterEach(cleanup)
 
@@ -32,6 +32,27 @@ describe('#styled', () => {
       color: red;
       margin: 8px;
     `)
+  })
+
+  it('works with keyframes', () => {
+    const animation = keyframes`
+      from {
+        transform: translateX(0%);
+      }
+
+      to {
+        transform: translateX(100%);
+      }
+    `
+    const Dummy = styled.div`
+      ${css`
+        animation: ${animation};
+      `}
+    `
+
+    const { container } = render(<Dummy />)
+
+    expect(container.firstChild).toHaveStyle(`animation: ${animation.name};`)
   })
 
   it('reads value from the theme', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,13 +3224,6 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browser-resolve@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-2.0.0.tgz#99b7304cb392f8d73dba741bb2d7da28c6d7842b"
-  integrity sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==
-  dependencies:
-    resolve "^1.17.0"
-
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"


### PR DESCRIPTION
## Summary

Makes `keyframes` from emotion available through xstyled
