### PR TITLE
fix(breakpoints): multiple responsive style props

### DIFF
--- a/packages/system/src/style.js
+++ b/packages/system/src/style.js
@@ -187,6 +187,8 @@ export function compose(...generators) {
 
   function getStyle(props) {
     const styles = {}
+    const breakpoints = Object.values(getBreakpoints(props))
+
     for (const key in props) {
       const generator = generatorsByProp[key]
       if (generator) {
@@ -194,7 +196,21 @@ export function compose(...generators) {
         merge(styles, style)
       }
     }
-    return styles
+
+    const medias = breakpoints.reduce((mediasAcc, breakpoint) => {
+      const currentMediaKey = `@media (min-width: ${breakpoint}px)`;
+      const isValid = Object.keys(styles).includes(currentMediaKey);
+      if(!isValid) return mediasAcc;
+      return {
+        ...mediasAcc,
+        [currentMediaKey]: styles[currentMediaKey]
+      };
+    }, {});
+    
+    return {
+      ...medias,
+      ...styles,
+    }
   }
 
   const props = flatGenerators.reduce(
@@ -204,6 +220,7 @@ export function compose(...generators) {
 
   return createStyleGenerator(getStyle, props, generators)
 }
+
 
 export function style({
   prop,

--- a/packages/system/src/style.js
+++ b/packages/system/src/style.js
@@ -173,11 +173,13 @@ function indexGeneratorsByProp(styles) {
 
 function getMediaOrder(styles, props) {
   const medias = {} 
-  const breakpoints = Object.values(getBreakpoints(props))
+  const breakpoints = getBreakpoints(props)
+  const stylesProperties = Object.keys(styles)
 
-  for (const breakpoint in breakpoints) {
-    const currentMediaKey = `@media (min-width: ${breakpoints[breakpoint]}px)`;
-    const isValid = Object.keys(styles).includes(currentMediaKey);
+  for (const key in breakpoints) {
+    const breakpoint = breakpoints[key]
+    const currentMediaKey = `@media (min-width: ${breakpoint}px)`;
+    const isValid = stylesProperties.includes(currentMediaKey);
 
     if (!isValid) continue
     medias[currentMediaKey] = styles[currentMediaKey]

--- a/packages/system/src/style.js
+++ b/packages/system/src/style.js
@@ -171,6 +171,21 @@ function indexGeneratorsByProp(styles) {
   return index
 }
 
+function getMediaOrder(styles, props) {
+  const medias = {} 
+  const breakpoints = Object.values(getBreakpoints(props))
+
+  for (const breakpoint in breakpoints) {
+    const currentMediaKey = `@media (min-width: ${breakpoints[breakpoint]}px)`;
+    const isValid = Object.keys(styles).includes(currentMediaKey);
+
+    if (!isValid) continue
+    medias[currentMediaKey] = styles[currentMediaKey]
+  }
+
+  return medias
+}
+
 export function compose(...generators) {
   let flatGenerators = []
   generators.forEach((gen) => {
@@ -187,8 +202,6 @@ export function compose(...generators) {
 
   function getStyle(props) {
     const styles = {}
-    const breakpoints = Object.values(getBreakpoints(props))
-
     for (const key in props) {
       const generator = generatorsByProp[key]
       if (generator) {
@@ -197,20 +210,7 @@ export function compose(...generators) {
       }
     }
 
-    const medias = breakpoints.reduce((mediasAcc, breakpoint) => {
-      const currentMediaKey = `@media (min-width: ${breakpoint}px)`;
-      const isValid = Object.keys(styles).includes(currentMediaKey);
-      if(!isValid) return mediasAcc;
-      return {
-        ...mediasAcc,
-        [currentMediaKey]: styles[currentMediaKey]
-      };
-    }, {});
-    
-    return {
-      ...medias,
-      ...styles,
-    }
+    return assign(getMediaOrder(styles, props), styles);
   }
 
   const props = flatGenerators.reduce(
@@ -220,7 +220,6 @@ export function compose(...generators) {
 
   return createStyleGenerator(getStyle, props, generators)
 }
-
 
 export function style({
   prop,


### PR DESCRIPTION
## Summary

Hello folks!
There is a bug when passing several responsive style props, the order of the resulting media queries is wrong.
More details on this in issue [#119](https://github.com/smooth-code/xstyled/issues/119)
Example 
Code:
```
<Box 
  pt={{ sm: 0, lg: 60 }}
  pb={{ md: 20, lg: 60 }}
  bg={{ xs: 'blue', md: 'red', lg: 'green', xl: '#000000'}}
>
  hello
</Box>
```

![Screen Shot 2020-10-27 at 6 39 56 PM](https://user-images.githubusercontent.com/999120/97365309-3e9a9580-1884-11eb-9d75-60fb01ab33da.png)


## Test plan
The idea is to organize the order of @medias based on the breakpoint values. A function was created to guarantee the order of the breakpoints, without the need to add complexity to the `merge` function.

![Screen Shot 2020-10-27 at 6 39 20 PM](https://user-images.githubusercontent.com/999120/97365364-52de9280-1884-11eb-8c8b-f7cc88e18f4a.png)

