### PR TITLE
feat(prop-types): Add bool option to the prop-types to use it with col and row props

### DIFF
--- a/packages/prop-types/src/index.js
+++ b/packages/prop-types/src/index.js
@@ -1,9 +1,9 @@
-import { oneOfType, number, string, object } from 'prop-types'
+import { oneOfType, number, string, object, bool } from 'prop-types'
 
 export function getSystemPropTypes(system) {
   if (!system) return {}
   return system.meta.props.reduce((obj, prop) => {
-    obj[prop] = oneOfType([number, string, object])
+    obj[prop] = oneOfType([number, string, object, bool])
     return obj
   }, {})
 }


### PR DESCRIPTION
## Summary

When composing the component styles using the `xgrids + getSystemProps` it shoots warnings in the console because the bool option is not enabled in the `@xstyled/prop-types`, it means that the props `col` and `row` will not pass the proptypes validation.

For my specific case, I work in a project where warning are not allowed in the tests and because of that the props `col` and `row` are breaking the tests

## Test plan

```jsx
// Component
import React from 'react'
import { PropTypes } from 'prop-types'
import { getSystemPropTypes } from '@xstyled/prop-types'
import StyledField, { systemProps } from './Field.styled'

const Field = StyledField

Field.propTypes = {
  children: PropTypes.node.isRequired,
  ...getSystemPropTypes(systemProps),
}

export default Field

// Styles
import styled from '@xstyled/emotion'
import { compose, space, flexboxes, xgrids } from '@xstyled/system'

export const systemProps = compose(space, flexboxes, xgrids)

const defaults = {}
const StyledField = styled.div(defaults, systemProps, { flexGrow: 0 })

export default StyledField

// Usage
import Field from './Field'

export default () => {
  // Warning: Failed prop type: Invalid prop `row` supplied to `Field`
  return <Filed row /* or col */ />
}
```