### PR TITLE
chore(deps): bump styled-components to 5.2.1

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@xstyled/styled-components": "^1.17.1",
-    "styled-components": "^5.1.0",
+    "styled-components": "^5.2.1",
     "styled-system": "^5.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "rollup-plugin-size-snapshot": "^0.12.0",
     "rollup-plugin-terser": "^7.0.2",
     "shx": "^0.3.2",
-    "styled-components": "5.1.0"
+    "styled-components": "5.2.1"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "react-live": "^2.2.2",
     "reakit": "^1.1.2",
     "smooth-doc": "^4.0.3",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.2.1"
   },
   "devDependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9944,10 +9944,10 @@ stubs@^3.0.0:
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha1-6NK6H6nJBXAwPAMLaQD31fiavls=
 
-styled-components@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.0.tgz#2e3985b54f461027e1c91af3229e1c2530872a4e"
-  integrity sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==
+styled-components@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.1.tgz#6ed7fad2dc233825f64c719ffbdedd84ad79101a"
+  integrity sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.5"


### PR DESCRIPTION
Version 5.21 has some important improvements

## Summary

Bumps [styled-components](https://github.com/styled-components/styled-components) from 5.1.0 to 5.2.1.
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/styled-components/styled-components/releases">styled-components's releases</a>.</em></p>
<blockquote>

<h2>v5.2.1</h2>
<p>Tweak server-side build settings to resolve an issue with jest-dom not being able to pick up generated styles (see <a href="https://github.com/styled-components/styled-components/pull/3308" data-hovercard-type="pull_request" data-hovercard-url="/styled-components/styled-components/pull/3308/hovercard">#3308</a>) thanks <a class="user-mention" data-hovercard-type="user" data-hovercard-url="/users/Lazyuki/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/Lazyuki">@Lazyuki</a></p>

<h2>v5.2.0</h2>

<p>Make sure <code>StyleSheetManager</code> renders all styles in iframe / child windows (see <a href="https://github-redirect.dependabot.com/styled-components/styled-components/pull/3159">#3159</a>) thanks <a href="https://github.com/eramdam">@eramdam</a>!</p>

<p>Rework how components self-reference in extension scenarios (see <a href="https://github-redirect.dependabot.com/styled-components/styled-components/pull/3236">#3236</a>); should fix a bunch of subtle bugs around patterns like <code>&amp; + &amp;</code></p>

<p>Fix <code>keyframes</code> not receiving a modified stylis instance when using something like <code>stylis-plugin-rtl</code> (see <a href="https://github-redirect.dependabot.com/styled-components/styled-components/pull/3239">#3239</a>)</p>

<p>Big performance gain for components using <a href="https://styled-components.com/docs/advanced#style-objects">style objects</a> (see <a href="https://github-redirect.dependabot.com/styled-components/styled-components/pull/3239">#3239</a>)</p>

<p>We no longer emit dynamic classNames for empty rulesets, so some className churn may occur in snapshots</p>

<p>Preallocate global style placement to ensure cGS is consistently inserted at the top of the stylesheet; note that this is done in <em>runtime order</em> so, if you have multiple cGS that have overlapping styles, ensure they're defined in code in the sequence you would want them injected (see <a href="https://github-redirect.dependabot.com/styled-components/styled-components/pull/3239">#3239</a>)</p>

<p>Add &quot;engines&quot; to package.json (currently set to Node 10, the oldest supported LTS distribution) (see <a href="https://github-redirect.dependabot.com/styled-components/styled-components/pull/3201">#3201</a>) thanks <a href="https://github.com/MichaelDeBoey">@MichaelDeBoey</a>!</p>

<p>Finally, special thanks to <a href="https://github.com/willheslam">@willheslam</a> for testing and some last minute fixes on this release!</p>

</blockquote>
---

## Test plan
`yarn test` - All tests passed

![Screen Shot 2020-11-10 at 1 38 03 PM](https://user-images.githubusercontent.com/999120/98703217-069e5280-235a-11eb-8884-fea51c062631.png)
